### PR TITLE
Skipped adding workloads without a uuid and added check for null packageKey

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -289,9 +289,13 @@ export class APIClient {
     do {
       workloads = await this.fetchWorkloads(offset);
 
-      offset = workloads.offset;
-      if (workloads.results.length) {
+      // If the workload has no results then stop iterating through
+      // workloads and skip adding uuids.
+      if (workloads.results && workloads.results.length) {
         workloads.results.forEach((workload) => uuids.add(workload?.uuid));
+        offset = workloads.offset;
+      } else {
+        offset = undefined;
       }
     } while (workloads.offset);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -290,7 +290,9 @@ export class APIClient {
       workloads = await this.fetchWorkloads(offset);
 
       offset = workloads.offset;
-      workloads.results.forEach((workload) => uuids.add(workload.uuid));
+      if (workloads.results.length) {
+        workloads.results.forEach((workload) => uuids.add(workload?.uuid));
+      }
     } while (workloads.offset);
 
     for (const uuid of uuids) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -294,6 +294,9 @@ export class APIClient {
     } while (workloads.offset);
 
     for (const uuid of uuids) {
+      if (!uuid) {
+        continue;
+      }
       await iteratee(await this.fetchWorkload(uuid));
     }
   }

--- a/src/steps/package/index.ts
+++ b/src/steps/package/index.ts
@@ -121,7 +121,7 @@ export async function fetchWorkloadFindings({
           for (const package_info of workloadFinding.package_infos || []) {
             // Iterates over each package used by this workload
             // with the matching name and version.
-            for (const package_key of packageKeys.get(
+            for (const package_key of packageKeys?.get(
               `${package_info.name}:${package_info.version}`,
             ) || []) {
               const package_entity = await jobState.findEntity(package_key);


### PR DESCRIPTION
# Description

Skipped adding workloads without a uuid and added check for null packageKey.

## Summary
INT-4424:
If a workload has a null uuid we are unable to get packages/vulnerabilities/scopes related to it so it would have no relationships. Workloads with a null uuid can be skipped.

INT-4425:
packageKeys didn't exist in some cases because of a null uuid. Since workload uuid's cannot be null anymore this issue should be fixed, but a check for a null packageKeys was added in case.

## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
