### PR TITLE
fix incorrect logic for retry count

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -49,11 +49,11 @@ export class APIClient {
       this.REQUEST_CONFIG.RETRY_METHODS.includes(init.method);
     const retryCount = retry ? Math.max(this.REQUEST_CONFIG.MAX_RETRIES, 1) : 1;
     let response: Response;
-    for (let i = 1; i <= retryCount; i++) {
+    for (let i = 1; i <= retryCount + 1; i++) {
       try {
         response = await fetch(url, init);
       } catch (error) {
-        if (i === retryCount - 1) {
+        if (i === retryCount + 1) {
           throw error;
         }
         // Sleep for 2, 4, 8, 16, or 32 seconds depending on retry number
@@ -64,7 +64,7 @@ export class APIClient {
       }
       if (
         !this.REQUEST_CONFIG.RETRY_HTTP_CODES.includes(response.status) ||
-        i === retryCount - 1
+        i === retryCount + 1
       ) {
         return response;
       }


### PR DESCRIPTION
Fixes logic error causing it to exit early out of retries. Now it will make the initial attempt + 5 retries:
```
Attempt #1
sleep 2
Attempt #2
sleep 4
Attempt #3
sleep 8
Attempt #4
sleep 16
Attempt #5
sleep 32
Attempt #6
throw/return
```